### PR TITLE
Upstream csv-to-google-spreadsheet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY importer.py .
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 
-ENTRYPOINT python3 importer.py
+ENTRYPOINT ["python3", "/importer.py"]

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,9 @@ inputs:
     description: ''
     required: true
   worksheet:
-    description: ''
+    description: 'Index of worksheet in Spreadsheet. Index starts from zero.'
     required: true
+    default: 0
   append_content:
     description: ''
     required: false

--- a/importer.py
+++ b/importer.py
@@ -8,7 +8,7 @@ from google.oauth2.service_account import Credentials
 # Input vars
 csv_path = getenv("INPUT_CSV_PATH")
 spreadsheet_id = getenv("INPUT_SPREADSHEET_ID")
-worksheet = int(getenv("INPUT_WORKSHEET", 0))
+worksheet_id = int(getenv("INPUT_WORKSHEET", 0))
 append_content = strtobool(getenv("INPUT_APPEND_CONTENT", "False"))
 
 service_account_info = {
@@ -46,7 +46,7 @@ creds = Credentials.from_service_account_info(
 client = gspread.authorize(creds)
 
 spreadsheet = client.open_by_key(spreadsheet_id)
-ws = spreadsheet.get_worksheet(0)
+ws = spreadsheet.get_worksheet(worksheet_id)
 
 if append_content:
     start_from = f"A{next_available_row(ws)}"

--- a/importer.py
+++ b/importer.py
@@ -8,7 +8,7 @@ from google.oauth2.service_account import Credentials
 # Input vars
 csv_path = getenv("INPUT_CSV_PATH")
 spreadsheet_id = getenv("INPUT_SPREADSHEET_ID")
-worksheet_id = int(getenv("INPUT_WORKSHEET", 0))
+worksheet_id = int(getenv("INPUT_WORKSHEET"))
 append_content = strtobool(getenv("INPUT_APPEND_CONTENT", "False"))
 
 service_account_info = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==4.0.0
-google-auth==1.33.1
+google-auth==1.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gspread==3.6.0
+gspread==3.7.0
 google-auth==1.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.6.0
-google-auth==1.16.0
+google-auth==1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gspread==3.7.0
+gspread==4.0.0
 google-auth==1.33.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.7.0
-google-auth==1.28.1
+google-auth==1.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.6.0
-google-auth==1.26.0
+google-auth==1.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.7.0
-google-auth==1.28.0
+google-auth==1.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.6.0
-google-auth==1.23.0
+google-auth==1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.7.0
-google-auth==1.33.0
+google-auth==1.33.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.7.0
-google-auth==1.32.1
+google-auth==1.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==3.7.0
-google-auth==1.30.0
+google-auth==1.32.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gspread==4.0.0
-google-auth==1.34.0
+google-auth==2.13.0


### PR DESCRIPTION
I used your example from https://github.com/NiklasMerz/netlify-analytics-collector and found this error near the end:

* https://github.com/fluxcd/stats/pull/10

Some of the fixes in your `allfixes` branch of your fork at https://github.com/NiklasMerz/csv-to-google-spreadsheet were upstreamed in the now-archived https://github.com/canonical-web-and-design/csv-to-google-spreadsheet – the fixes made it to upstream `master` but your own `master` is behind `allfixes`, and that means your example is actually missing the fix.

Thank you for fixing the issue and getting it upstreamed! Too bad that project is archived, but good news is it still works 🎉 

Simply merging this PR should be enough to fix the example for good! Welcome to tag a matching 1.0.1 or whatever else.

I really appreciate that you published this, and fixed the issues with the dependency and got them merged upstream. This was a breeze to implement on our Netlify site and so far looks to be exactly what we wanted.

If you intentionally noticed this adapter was EOL and didn't want to become a new upstream, then I understand and I guess I'm the new upstream now, adopted csv-to-google-spreadsheet at: https://github.com/kingdonb/csv-to-google-spreadsheet

😄 Cheers 🥇 